### PR TITLE
Fix TeamsTenantFilteringMiddleware

### DIFF
--- a/CSharp/Microsoft.Bot.Builder.Teams/Microsoft.Bot.Builder.Teams.csproj
+++ b/CSharp/Microsoft.Bot.Builder.Teams/Microsoft.Bot.Builder.Teams.csproj
@@ -7,7 +7,8 @@
   <Import Project="..\Build\Common.props" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.0.7" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.2" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CSharp/Microsoft.Bot.Builder.Teams/Microsoft.Bot.Builder.Teams.csproj
+++ b/CSharp/Microsoft.Bot.Builder.Teams/Microsoft.Bot.Builder.Teams.csproj
@@ -7,8 +7,7 @@
   <Import Project="..\Build\Common.props" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.2" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.2.2" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CSharp/Microsoft.Bot.Builder.Teams/Middlewares/DropNonTeamsActivitiesMiddleware.cs
+++ b/CSharp/Microsoft.Bot.Builder.Teams/Middlewares/DropNonTeamsActivitiesMiddleware.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Bot.Builder.Teams.Middlewares
     using System;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Bot.Connector;
 
     /// <summary>
     /// Automatically drop all messages received from any channel except Microsoft Teams.
@@ -37,7 +38,7 @@ namespace Microsoft.Bot.Builder.Teams.Middlewares
         {
             BotAssert.ContextNotNull(turnContext);
 
-            if (turnContext.Activity.ChannelId.Equals("msteams", StringComparison.OrdinalIgnoreCase))
+            if (turnContext.Activity.ChannelId.Equals(Channels.Msteams, StringComparison.OrdinalIgnoreCase))
             {
                 await next(cancellationToken).ConfigureAwait(false);
             }

--- a/CSharp/Microsoft.Bot.Builder.Teams/Middlewares/TeamsMiddleware.cs
+++ b/CSharp/Microsoft.Bot.Builder.Teams/Middlewares/TeamsMiddleware.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Bot.Builder.Teams.Middlewares
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Bot.Builder.Teams.Internal;
+    using Microsoft.Bot.Connector;
     using Microsoft.Bot.Connector.Authentication;
     using Microsoft.Bot.Connector.Teams;
     using Microsoft.Rest.TransientFaultHandling;
@@ -84,7 +85,7 @@ namespace Microsoft.Bot.Builder.Teams.Middlewares
         {
             BotAssert.ContextNotNull(context);
 
-            if (context.Activity.ChannelId.Equals("msteams", StringComparison.OrdinalIgnoreCase))
+            if (context.Activity.ChannelId.Equals(Channels.Msteams, StringComparison.OrdinalIgnoreCase))
             {
                 // BotFrameworkAdapter when processing activity, post Auth adds BotIdentity into the context.
                 ClaimsIdentity claimsIdentity = context.TurnState.Get<ClaimsIdentity>("BotIdentity");

--- a/CSharp/Microsoft.Bot.Builder.Teams/Middlewares/TeamsTenantFilteringMiddleware.cs
+++ b/CSharp/Microsoft.Bot.Builder.Teams/Middlewares/TeamsTenantFilteringMiddleware.cs
@@ -55,8 +55,13 @@ namespace Microsoft.Bot.Builder.Teams.Middlewares
         {
             TeamsChannelData teamsChannelData = turnContext.Activity.GetChannelData<TeamsChannelData>();
             string tenantId = teamsChannelData?.Tenant?.Id;
+            
+            if (string.IsNullOrEmpty(tenantId))
+            {
+                throw new UnauthorizedAccessException("Tenant Id is missing.");
+            }
 
-            if (string.IsNullOrEmpty(tenantId) || !this.tenantMap.ContainsKey(tenantId))
+            if (!this.tenantMap.ContainsKey(tenantId))
             {
                 throw new UnauthorizedAccessException("Tenant Id '" + tenantId + "' is not allowed access.");
             }

--- a/CSharp/Microsoft.Bot.Builder.Teams/Middlewares/TeamsTenantFilteringMiddleware.cs
+++ b/CSharp/Microsoft.Bot.Builder.Teams/Middlewares/TeamsTenantFilteringMiddleware.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Bot.Builder.Teams.Middlewares
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Bot.Connector;
     using Microsoft.Bot.Schema.Teams;
 
     /// <summary>
@@ -58,7 +59,7 @@ namespace Microsoft.Bot.Builder.Teams.Middlewares
         /// <seealso cref="Schema.IActivity" />
         public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (!turnContext.Activity.ChannelId.Equals("msteams", StringComparison.OrdinalIgnoreCase))
+            if (!turnContext.Activity.ChannelId.Equals(Channels.Msteams, StringComparison.OrdinalIgnoreCase))
             {
                 await next(cancellationToken).ConfigureAwait(false);
                 return;

--- a/CSharp/Microsoft.Bot.Schema.Teams/Microsoft.Bot.Schema.Teams.csproj
+++ b/CSharp/Microsoft.Bot.Schema.Teams/Microsoft.Bot.Schema.Teams.csproj
@@ -7,7 +7,7 @@
   <Import Project="..\Build\Common.props" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.2.2" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
   </ItemGroup>
 </Project>

--- a/CSharp/Microsoft.Bot.Schema.Teams/Microsoft.Bot.Schema.Teams.csproj
+++ b/CSharp/Microsoft.Bot.Schema.Teams/Microsoft.Bot.Schema.Teams.csproj
@@ -7,7 +7,7 @@
   <Import Project="..\Build\Common.props" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.0.7" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
   </ItemGroup>
 </Project>

--- a/CSharp/Samples/Microsoft.Bot.Builder.Abstractions/Microsoft.Bot.Builder.Abstractions.csproj
+++ b/CSharp/Samples/Microsoft.Bot.Builder.Abstractions/Microsoft.Bot.Builder.Abstractions.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.2" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/CSharp/Samples/Microsoft.Bot.Builder.Abstractions/Microsoft.Bot.Builder.Abstractions.csproj
+++ b/CSharp/Samples/Microsoft.Bot.Builder.Abstractions/Microsoft.Bot.Builder.Abstractions.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.0.7" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/CSharp/Samples/Microsoft.Bot.Builder.Teams.AuditBot.AspNet/Microsoft.Bot.Builder.Teams.AuditBot.AspNet.csproj
+++ b/CSharp/Samples/Microsoft.Bot.Builder.Teams.AuditBot.AspNet/Microsoft.Bot.Builder.Teams.AuditBot.AspNet.csproj
@@ -128,10 +128,10 @@
       <Version>5.2.4</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.WebApi">
-      <Version>4.2.2</Version>
+      <Version>4.1.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Bot.Configuration">
-      <Version>4.2.2</Version>
+      <Version>4.1.1</Version>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
       <Version>1.1.0-beta008</Version>

--- a/CSharp/Samples/Microsoft.Bot.Builder.Teams.AuditBot.AspNet/Microsoft.Bot.Builder.Teams.AuditBot.AspNet.csproj
+++ b/CSharp/Samples/Microsoft.Bot.Builder.Teams.AuditBot.AspNet/Microsoft.Bot.Builder.Teams.AuditBot.AspNet.csproj
@@ -128,10 +128,10 @@
       <Version>5.2.4</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.WebApi">
-      <Version>4.0.7</Version>
+      <Version>4.2.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Bot.Configuration">
-      <Version>4.0.7</Version>
+      <Version>4.2.2</Version>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
       <Version>1.1.0-beta008</Version>

--- a/CSharp/Samples/Microsoft.Bot.Builder.Teams.AuditBot/Microsoft.Bot.Builder.Teams.AuditBot.csproj
+++ b/CSharp/Samples/Microsoft.Bot.Builder.Teams.AuditBot/Microsoft.Bot.Builder.Teams.AuditBot.csproj
@@ -24,8 +24,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.2" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.1" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/CSharp/Samples/Microsoft.Bot.Builder.Teams.AuditBot/Microsoft.Bot.Builder.Teams.AuditBot.csproj
+++ b/CSharp/Samples/Microsoft.Bot.Builder.Teams.AuditBot/Microsoft.Bot.Builder.Teams.AuditBot.csproj
@@ -24,8 +24,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.0.7" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.0.7" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.2" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/CSharp/Samples/Microsoft.Bot.Builder.Teams.RemindMeBot/Microsoft.Bot.Builder.Teams.RemindMeBot.csproj
+++ b/CSharp/Samples/Microsoft.Bot.Builder.Teams.RemindMeBot/Microsoft.Bot.Builder.Teams.RemindMeBot.csproj
@@ -24,8 +24,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.2" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.1" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/CSharp/Samples/Microsoft.Bot.Builder.Teams.RemindMeBot/Microsoft.Bot.Builder.Teams.RemindMeBot.csproj
+++ b/CSharp/Samples/Microsoft.Bot.Builder.Teams.RemindMeBot/Microsoft.Bot.Builder.Teams.RemindMeBot.csproj
@@ -24,8 +24,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.0.7" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.0.7" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.2" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/CSharp/Samples/Microsoft.Bot.Builder.Teams.TeamEchoBot/Microsoft.Bot.Builder.Teams.TeamEchoBot.csproj
+++ b/CSharp/Samples/Microsoft.Bot.Builder.Teams.TeamEchoBot/Microsoft.Bot.Builder.Teams.TeamEchoBot.csproj
@@ -24,7 +24,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.0.7" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/CSharp/Samples/Microsoft.Bot.Builder.Teams.TeamEchoBot/Microsoft.Bot.Builder.Teams.TeamEchoBot.csproj
+++ b/CSharp/Samples/Microsoft.Bot.Builder.Teams.TeamEchoBot/Microsoft.Bot.Builder.Teams.TeamEchoBot.csproj
@@ -24,7 +24,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/CSharp/Samples/Microsoft.Bot.Builder.Teams.WikipediaMessagingExtension/Microsoft.Bot.Builder.Teams.WikipediaMessagingExtension.csproj
+++ b/CSharp/Samples/Microsoft.Bot.Builder.Teams.WikipediaMessagingExtension/Microsoft.Bot.Builder.Teams.WikipediaMessagingExtension.csproj
@@ -24,8 +24,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.2" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.1" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/CSharp/Samples/Microsoft.Bot.Builder.Teams.WikipediaMessagingExtension/Microsoft.Bot.Builder.Teams.WikipediaMessagingExtension.csproj
+++ b/CSharp/Samples/Microsoft.Bot.Builder.Teams.WikipediaMessagingExtension/Microsoft.Bot.Builder.Teams.WikipediaMessagingExtension.csproj
@@ -24,8 +24,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.0.7" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.0.7" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.2" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/CSharp/UnitTests/Microsoft.Bot.Builder.Teams.Tests/Microsoft.Bot.Builder.Teams.Tests.csproj
+++ b/CSharp/UnitTests/Microsoft.Bot.Builder.Teams.Tests/Microsoft.Bot.Builder.Teams.Tests.csproj
@@ -14,6 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.2.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />

--- a/CSharp/UnitTests/Microsoft.Bot.Builder.Teams.Tests/Microsoft.Bot.Builder.Teams.Tests.csproj
+++ b/CSharp/UnitTests/Microsoft.Bot.Builder.Teams.Tests/Microsoft.Bot.Builder.Teams.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.2.2" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />

--- a/CSharp/UnitTests/Microsoft.Bot.Builder.Teams.Tests/Middlewares/TeamsTenantFilteringMiddlewareTests.cs
+++ b/CSharp/UnitTests/Microsoft.Bot.Builder.Teams.Tests/Middlewares/TeamsTenantFilteringMiddlewareTests.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests.Middleware
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Bot.Builder.Teams.Middlewares;
+    using Microsoft.Bot.Connector;
     using Microsoft.Bot.Schema;
     using Microsoft.Bot.Schema.Teams;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -173,7 +174,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests.Middleware
         {
             return new Activity()
             {
-                ChannelId = teamsChannel ? "msteams" : "skype",
+                ChannelId = teamsChannel ? Channels.Msteams : Channels.Skype,
                 ChannelData = new TeamsChannelData
                 {
                     Tenant = tenantId == null ? null : new TenantInfo

--- a/CSharp/UnitTests/Microsoft.Bot.Builder.Teams.Tests/Middlewares/TeamsTenantFilteringMiddlewareTests.cs
+++ b/CSharp/UnitTests/Microsoft.Bot.Builder.Teams.Tests/Middlewares/TeamsTenantFilteringMiddlewareTests.cs
@@ -1,0 +1,187 @@
+﻿// <copyright file="TeamsTenantFilteringMiddlewareTests.cs" company="Microsoft">
+// Licensed under the MIT License.
+// </copyright>
+
+namespace Microsoft.Bot.Builder.Teams.Tests.Middleware
+{
+    using System;
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Bot.Builder.Teams.Middlewares;
+    using Microsoft.Bot.Schema;
+    using Microsoft.Bot.Schema.Teams;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    /// <summary>
+    /// Tests for the <see cref="TeamsTenantFilteringMiddleware"/> class.
+    /// </summary>
+    [TestClass]
+    public class TeamsTenantFilteringMiddlewareTests
+    {
+        /// <summary>
+        /// Check that the <see cref="TeamsTenantFilteringMiddleware(System.Collections.Generic.IEnumerable{string})"/> constructor
+        /// handles null arguments appropriately.
+        /// </summary>
+        [ExpectedException(typeof(ArgumentNullException))]
+        [TestMethod]
+        public void Constructor_Nulls()
+        {
+            var middleware = new TeamsTenantFilteringMiddleware(null);
+        }
+
+        /// <summary>
+        /// Check that OnTurnAsync does not call next if allows tenant list is empty on any tenant.
+        /// </summary>
+        /// <returns>A task.</returns>
+        [ExpectedException(typeof(UnauthorizedAccessException))]
+        [TestMethod]
+        public async Task OnTurnAsync_EmptyAllowedList_WithTenantIdAsync()
+        {
+            // Setup
+            var turnContextMock = new Mock<ITurnContext>();
+            var activity = this.TeamsActivityWithTenantId(true, "TenantId");
+            turnContextMock.Setup((turnContext) => turnContext.Activity).Returns(activity);
+            var middleware = new TeamsTenantFilteringMiddleware(new string[0]);
+            bool isDelegateCalled = false;
+            Task Next(CancellationToken cancellationToken) => Task.FromResult(isDelegateCalled = true);
+
+            // Action
+            await middleware.OnTurnAsync(turnContextMock.Object, Next).ConfigureAwait(false);
+
+            // Verify
+            Assert.IsFalse(isDelegateCalled); // This doesn't actually get called since we throw an exception.
+        }
+
+        /// <summary>
+        /// Check that OnTurnAsync does not call next if allows tenant list is empty on any tenant.
+        /// </summary>
+        /// <returns>A task.</returns>
+        [ExpectedException(typeof(UnauthorizedAccessException))]
+        [TestMethod]
+        public async Task OnTurnAsync_EmptyAllowedList_WithoutTenantIdAsync()
+        {
+            // Setup
+            var turnContextMock = new Mock<ITurnContext>();
+            var activity = this.TeamsActivityWithTenantId(true, null);
+            turnContextMock.Setup((turnContext) => turnContext.Activity).Returns(activity);
+            var middleware = new TeamsTenantFilteringMiddleware(new string[0]);
+            bool isDelegateCalled = false;
+            Task Next(CancellationToken cancellationToken) => Task.FromResult(isDelegateCalled = true);
+
+            // Action
+            await middleware.OnTurnAsync(turnContextMock.Object, Next).ConfigureAwait(false);
+
+            // Verify
+            Assert.IsFalse(isDelegateCalled); // This doesn't actually get called since we throw an exception.
+        }
+
+        /// <summary>
+        /// Check that OnTurnAsync calls next for tenant on allow list.
+        /// </summary>
+        /// <returns>A task.</returns>
+        [TestMethod]
+        public async Task OnTurnAsync_PopulatedAllowList_AllowedTenantAsync()
+        {
+            // Setup
+            var turnContextMock = new Mock<ITurnContext>();
+            var activity = this.TeamsActivityWithTenantId(true, "TenantId");
+            turnContextMock.Setup((turnContext) => turnContext.Activity).Returns(activity);
+            var middleware = new TeamsTenantFilteringMiddleware(new string[] { "TenantId" });
+            bool isDelegateCalled = false;
+            Task Next(CancellationToken cancellationToken) => Task.FromResult(isDelegateCalled = true);
+
+            // Action
+            await middleware.OnTurnAsync(turnContextMock.Object, Next).ConfigureAwait(false);
+
+            // Verify
+            Assert.IsTrue(isDelegateCalled); // This doesn't actually get called since we throw an exception.
+        }
+
+        /// <summary>
+        /// Check that OnTurnAsync does not call next for tenant not on allow list.
+        /// </summary>
+        /// <returns>A task.</returns>
+        [ExpectedException(typeof(UnauthorizedAccessException))]
+        [TestMethod]
+        public async Task OnTurnAsync_PopulatedAllowList_NotAllowedTenantAsync()
+        {
+            // Setup
+            var turnContextMock = new Mock<ITurnContext>();
+            var activity = this.TeamsActivityWithTenantId(true, "ADifferentTenantId");
+            turnContextMock.Setup((turnContext) => turnContext.Activity).Returns(activity);
+            var middleware = new TeamsTenantFilteringMiddleware(new string[] { "TenantId" });
+            bool isDelegateCalled = false;
+            Task Next(CancellationToken cancellationToken) => Task.FromResult(isDelegateCalled = true);
+
+            // Action
+            await middleware.OnTurnAsync(turnContextMock.Object, Next).ConfigureAwait(false);
+
+            // Verify
+            Assert.IsFalse(isDelegateCalled); // This doesn't actually get called since we throw an exception.
+        }
+
+        /// <summary>
+        /// Check that OnTurnAsync does not call next for tenant not on allow list.
+        /// </summary>
+        /// <returns>A task.</returns>
+        [ExpectedException(typeof(UnauthorizedAccessException))]
+        [TestMethod]
+        public async Task OnTurnAsync_PopulatedAllowList_NoTenantAsync()
+        {
+            // Setup
+            var turnContextMock = new Mock<ITurnContext>();
+            var activity = this.TeamsActivityWithTenantId(true, null);
+            turnContextMock.Setup((turnContext) => turnContext.Activity).Returns(activity);
+            var middleware = new TeamsTenantFilteringMiddleware(new string[] { "TenantId" });
+            bool isDelegateCalled = false;
+            Task Next(CancellationToken cancellationToken) => Task.FromResult(isDelegateCalled = true);
+
+            // Action
+            await middleware.OnTurnAsync(turnContextMock.Object, Next).ConfigureAwait(false);
+
+            // Verify
+            Assert.IsFalse(isDelegateCalled); // This doesn't actually get called since we throw an exception.
+        }
+
+        /// <summary>
+        /// Check that OnTurnAsync does call next for other channels.
+        /// </summary>
+        /// <returns>A task.</returns>
+        [TestMethod]
+        public async Task OnTurnAsync_PopulatedAllowList_NotAllowedTenant_NotTeamsChannelAsync()
+        {
+            // Setup
+            var turnContextMock = new Mock<ITurnContext>();
+            var activity = this.TeamsActivityWithTenantId(false, "ADifferentTenantId");
+            turnContextMock.Setup((turnContext) => turnContext.Activity).Returns(activity);
+            var middleware = new TeamsTenantFilteringMiddleware(new string[] { "TenantId" });
+            bool isDelegateCalled = false;
+            Task Next(CancellationToken cancellationToken) => Task.FromResult(isDelegateCalled = true);
+
+            // Action
+            await middleware.OnTurnAsync(turnContextMock.Object, Next).ConfigureAwait(false);
+
+            // Verify
+            Assert.IsTrue(isDelegateCalled); // This doesn't actually get called since we throw an exception.
+        }
+
+        private Activity TeamsActivityWithTenantId(bool teamsChannel, string tenantId)
+        {
+            return new Activity()
+            {
+                ChannelId = teamsChannel ? "msteams" : "skype",
+                ChannelData = new TeamsChannelData
+                {
+                    Tenant = tenantId == null ? null : new TenantInfo
+                    {
+                        Id = tenantId,
+                    },
+                },
+            };
+        }
+    }
+}


### PR DESCRIPTION
Fixing two problems:
1. If I use the TeamsTenantFilterMiddleware, I should never receive a message without the correct tenant Id in it.
2. the function would never call next() so it would never actually process the message if this middleware was used.